### PR TITLE
Add standalone option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ These variables are set in `defaults/main.yml`:
 ---
 # defaults file for certbot
 
-# The certbot can configure either "apache", "haproxy" or "nginx".
+# The certbot can configure either "apache", "haproxy", "nginx" or run "standalone".
 certbot_system: apache
 
 # You can have multiple domains, as a list to request a certificate for.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for certbot
 
-# The certbot can configure either "apache", "haproxy" or "nginx".
+# The certbot can configure either "apache", "haproxy", "nginx" or run "standalone".
 certbot_system: apache
 
 # You can have multiple domains, as a list to request a certificate for.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,3 +7,4 @@
     state: restarted
   when:
     - not ansible_check_mode | bool
+    - certbot_system != "standalone"

--- a/molecule/default/collections.yml
+++ b/molecule/default/collections.yml
@@ -2,3 +2,4 @@
 collections:
   - name: community.docker
   - name: community.general
+  - name: ansible.posix

--- a/tasks/assert.yml
+++ b/tasks/assert.yml
@@ -5,7 +5,7 @@
     that:
       - certbot_system is defined
       - certbot_system is string
-      - certbot_system in [ "apache", "nginx", "haproxy" ]
+      - certbot_system in [ "apache", "nginx", "haproxy", "standalone" ]
     quiet: yes
 
 - name: test if certbot_domains is set correctly

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,20 @@
     name: "{{ certbot_packages }}"
     state: present
 
-- name: get and install certificates
+- name: get and install certificates (Standalone)
+  ansible.builtin.command: |
+    certbot certonly --noninteractive
+    --{{ certbot_system }}
+    --domain {{ certbot_domains | join(' --domain ') }}
+    --agree-tos
+    --email {{ certbot_email }}
+  args:
+    creates: /etc/letsencrypt/accounts
+  when:
+    - certbot_ci_mode is not defined
+    - certbot_system == "standalone"
+
+- name: get and install certificates (Managed)
   ansible.builtin.command: |
     certbot --noninteractive
     --{{ certbot_system }}
@@ -23,6 +36,7 @@
     creates: /etc/letsencrypt/accounts
   when:
     - certbot_ci_mode is not defined
+    - certbot_system != "standalone"
 
 - name: set up automatic renewal
   ansible.builtin.cron:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -20,6 +20,8 @@ _certbot_packages:
       - certbot-nginx
     RedHat-7:
       - python2-certbot-nginx
+  standalone:
+    default: []
 
 certbot_packages: "{{ _certbot_packages[certbot_system][ansible_os_family ~ '-' ~ ansible_distribution_major_version] | default(_certbot_packages[certbot_system][ansible_os_family] | default(_certbot_packages[certbot_system]['default'])) + certbot_package }}"
 
@@ -34,6 +36,8 @@ _certbot_system_to_restart:
     default: nginx
   haproxy:
     default: haproxy
+  standalone:
+    default: []
 
 certbot_system_to_restart: "{{ _certbot_system_to_restart[certbot_system][ansible_os_family] | default(_certbot_system_to_restart[certbot_system]['default']) }}"
 


### PR DESCRIPTION
Adds the ability to use the standalone mode. Useful for when you don't want to rely on any other server software running on the machine where you want to obtain a certificate.